### PR TITLE
refactor: Separate Seat type definition into its own file

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
-import { Seats, type Seat } from "@/components/seats";
+import { Seats } from "@/components/seats";
+import { type Seat } from "@/lib/seat";
 
 const seats: Seat[] = [
 	{ id: "A1", column: 1, row: 1, indexFromLeft: 1, status: "empty" },

--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -2,19 +2,7 @@
 
 import { useState, type Dispatch, type SetStateAction } from "react";
 import { Button } from "./ui/button";
-
-type SeatStatus = "empty" | "occupied" | "temp-occupied";
-
-interface Seat {
-	id: string;
-	column: number;
-	row: number;
-	/**
-	 * Index from left of its own sections and it should start from 1
-	 */
-	indexFromLeft: number;
-	status: SeatStatus;
-}
+import { type Seat } from "@/lib/seat";
 
 interface SeatsProps {
 	seats: Seat[];
@@ -146,4 +134,4 @@ function SeatsSeat(props: {
 	);
 }
 
-export { Seats, type Seat };
+export { Seats };

--- a/src/lib/seat.ts
+++ b/src/lib/seat.ts
@@ -1,0 +1,12 @@
+type SeatStatus = "empty" | "occupied" | "temp-occupied";
+
+export interface Seat {
+	id: string;
+	column: number;
+	row: number;
+	/**
+	 * Index from left of its own sections and it should start from 1
+	 */
+	indexFromLeft: number;
+	status: SeatStatus;
+}


### PR DESCRIPTION
Move the Seat type definition from seats.tsx to a new file seat.ts to improve code organization and clarity. Update imports accordingly.