### PR TITLE
refactor(seats): Update onClick handler to use onSelectSeat

### DIFF
--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { type Dispatch, type SetStateAction } from "react";
 import { Button } from "./ui/button";
 import { type Seat } from "@/lib/seat";
 import { useSeatSelection } from "@/hooks/use-seat-selection";
@@ -24,7 +23,7 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 						seatsByColumn={seatSelection.seatsByColumn}
 						rowKey={rowKey}
 						selectedSeat={seatSelection.selectedSeat}
-						setSelectedSeat={seatSelection.setSelectedSeat}
+						onSelectSeat={seatSelection.onSelectSeat}
 					/>
 				</div>
 			))}
@@ -34,10 +33,10 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 }
 
 function SeatsColumns(props: {
-	seatsByColumn: Record<number, Record<number, Seat[]>>;
+	seatsByColumn: ReturnType<typeof useSeatSelection>["seatsByColumn"];
 	rowKey: number;
-	selectedSeat: Seat[];
-	setSelectedSeat: Dispatch<SetStateAction<Seat[]>>;
+	selectedSeat: ReturnType<typeof useSeatSelection>["selectedSeat"];
+	onSelectSeat: ReturnType<typeof useSeatSelection>["onSelectSeat"];
 }): JSX.Element {
 	const columns = Object.keys(props.seatsByColumn[props.rowKey]);
 
@@ -53,11 +52,11 @@ function SeatsColumns(props: {
 }
 
 function SeatsSeats(props: {
-	seatsByColumn: Record<number, Record<number, Seat[]>>;
+	seatsByColumn: ReturnType<typeof useSeatSelection>["seatsByColumn"];
 	rowKey: number;
 	columnKey: number;
-	selectedSeat: Seat[];
-	setSelectedSeat: Dispatch<SetStateAction<Seat[]>>;
+	selectedSeat: ReturnType<typeof useSeatSelection>["selectedSeat"];
+	onSelectSeat: ReturnType<typeof useSeatSelection>["onSelectSeat"];
 }): JSX.Element {
 	const seats =
 		props.seatsByColumn[Number(props.rowKey)][Number(props.columnKey)];
@@ -75,28 +74,18 @@ function SeatsSeat(props: {
 	seat: Seat;
 	rowKey: number;
 	columnKey: number;
-	selectedSeat: Seat[];
-	setSelectedSeat: Dispatch<SetStateAction<Seat[]>>;
+	selectedSeat: ReturnType<typeof useSeatSelection>["selectedSeat"];
+	onSelectSeat: ReturnType<typeof useSeatSelection>["onSelectSeat"];
 }): JSX.Element {
 	const selected = props.selectedSeat.some(
 		(_seat) => _seat.id === props.seat.id,
 	);
 
-	function onSelectSeat(): void {
-		props.setSelectedSeat((prevSelectedSeat) => {
-			if (prevSelectedSeat.some((_seat) => _seat.id === props.seat.id)) {
-				return prevSelectedSeat.filter(
-					(_seat) => _seat.id !== props.seat.id,
-				);
-			}
-
-			return [...prevSelectedSeat, props.seat];
-		});
-	}
-
 	return (
 		<Button
-			onClick={onSelectSeat}
+			onClick={() => {
+				props.onSelectSeat(props.seat.id);
+			}}
 			disabled={props.seat.status === "occupied"}
 			variant={selected ? "default" : "outline"}
 			className="size-10 rounded-full"

--- a/src/hooks/use-seat-selection.ts
+++ b/src/hooks/use-seat-selection.ts
@@ -1,11 +1,11 @@
 import { type Seat, getSeatsByColumn, getSeatsByRow } from "@/lib/seat";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import { useState, useCallback } from "react";
 
 export function useSeatSelection(seats: Seat[]): {
 	seatsByRow: Record<number, Seat[]>;
 	seatsByColumn: Record<number, Record<number, Seat[]>>;
 	selectedSeat: Seat[];
-	setSelectedSeat: Dispatch<SetStateAction<Seat[]>>;
+	onSelectSeat: (seatId: string) => void;
 } {
 	const [selectedSeat, setSelectedSeat] = useState<Seat[]>([]);
 
@@ -13,5 +13,23 @@ export function useSeatSelection(seats: Seat[]): {
 
 	const seatsByColumn = getSeatsByColumn(seatsByRow);
 
-	return { seatsByRow, seatsByColumn, selectedSeat, setSelectedSeat };
+	const onSelectSeat = useCallback(
+		(seatId: string) => {
+			const seat = seats.find((_seat) => _seat.id === seatId);
+			if (!seat) return;
+
+			setSelectedSeat((prevSelectedSeat) => {
+				if (prevSelectedSeat.some((_seat) => _seat.id === seatId)) {
+					return prevSelectedSeat.filter(
+						(_seat) => _seat.id !== seatId,
+					);
+				}
+
+				return [...prevSelectedSeat, seat];
+			});
+		},
+		[seats],
+	);
+
+	return { seatsByRow, seatsByColumn, selectedSeat, onSelectSeat };
 }


### PR DESCRIPTION
Refactored the onClick handler in the SeatsSeat component to use the
onSelectSeat function passed from the useSeatSelection hook instead of
directly setting the selected seat state. This improves separation of
concerns and enhances code readability.