### PR TITLE
refactor(seats): Update seat selection state management

### DIFF
--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -15,12 +15,6 @@ interface SeatsProps {
 function Seats({ seats }: SeatsProps): JSX.Element {
 	const seatSelection = useSeatSelection(seats);
 
-	const [selectionErrorIds, setSelectionErrorIds] = useState<string[]>([]);
-
-	const [selectionSuccessIds, setSelectionSuccessIds] = useState<string[]>(
-		[],
-	);
-
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
 	const seatRows = Object.keys(seatSelection.seatsByRow).map((rowKey) =>
@@ -28,8 +22,8 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 	);
 
 	const submitSelectSeat = useCallback(async () => {
-		setSelectionErrorIds([]);
-		setSelectionSuccessIds([]);
+		seatSelection.setSelectionErrorIds([]);
+		seatSelection.setSelectionSuccessIds([]);
 		setIsSubmitting(true);
 		const selectedSeatsIds = seatSelection.selectedSeat.map(
 			(seat) => seat.id,
@@ -56,13 +50,17 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 			const filteredSuccess = res.filter((r) => r.success);
 
 			if (filteredErrors.length) {
-				setSelectionErrorIds(filteredErrors.map((r) => r.seatId));
+				seatSelection.setSelectionErrorIds(
+					filteredErrors.map((r) => r.seatId),
+				);
 
 				filteredErrors
 					.map((r) => r.message as string)
 					.forEach((error) => toast.error(error));
 			}
-			setSelectionSuccessIds(filteredSuccess.map((r) => r.seatId));
+			seatSelection.setSelectionSuccessIds(
+				filteredSuccess.map((r) => r.seatId),
+			);
 		} catch (error) {
 			if (error instanceof Error) {
 				toast.error(error.message);
@@ -70,7 +68,7 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 		} finally {
 			setIsSubmitting(false);
 		}
-	}, [seatSelection.selectedSeat]);
+	}, [seatSelection]);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -86,8 +84,8 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 								rowKey={rowKey}
 								selectedSeat={seatSelection.selectedSeat}
 								onSelectSeat={seatSelection.onSelectSeat}
-								errorIds={selectionErrorIds}
-								successIds={selectionSuccessIds}
+								errorIds={seatSelection.selectionErrorIds}
+								successIds={seatSelection.selectionSuccessIds}
 							/>
 						</div>
 					))}

--- a/src/hooks/use-seat-selection.ts
+++ b/src/hooks/use-seat-selection.ts
@@ -5,15 +5,32 @@ import {
 	pickSeats,
 	toggleSeat,
 } from "@/lib/seat";
-import { useCallback, useState } from "react";
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
+import { toast } from "sonner";
 
 export function useSeatSelection(seats: Seat[]): {
 	seatsByRow: Record<number, Seat[]>;
 	seatsByColumn: Record<number, Record<number, Seat[]>>;
 	selectedSeat: Seat[];
 	onSelectSeat: (seatId: string) => void;
+	selectionErrorIds: string[];
+	setSelectionErrorIds: Dispatch<SetStateAction<string[]>>;
+	selectionSuccessIds: string[];
+	setSelectionSuccessIds: Dispatch<SetStateAction<string[]>>;
 } {
 	const [selectedSeat, setSelectedSeat] = useState<Seat[]>([]);
+
+	const [selectionErrorIds, setSelectionErrorIds] = useState<string[]>([]);
+
+	const [selectionSuccessIds, setSelectionSuccessIds] = useState<string[]>(
+		[],
+	);
 
 	const seatsByRow = getSeatsByRow(seats);
 
@@ -21,17 +38,47 @@ export function useSeatSelection(seats: Seat[]): {
 
 	const onSelectSeat = useCallback(
 		(seatId: string) => {
+			toast.dismiss();
 			const seat = seats.find((_seat) => _seat.id === seatId);
 			if (!seat) return;
 
 			setSelectedSeat((prevSelectedSeat) =>
 				toggleSeat(prevSelectedSeat, seat),
 			);
-
-			// const res = pickSeats(seats, body.selectedSeatsIds);
 		},
 		[seats],
 	);
 
-	return { seatsByRow, seatsByColumn, selectedSeat, onSelectSeat };
+	useEffect(() => {
+		if (selectedSeat.length > 0) {
+			const res = pickSeats(
+				seats,
+				selectedSeat.map((seat) => seat.id),
+			);
+
+			const filteredErrors = res.filter((r) => !r.success);
+
+			const filteredSuccess = res.filter((r) => r.success);
+
+			if (filteredErrors.length) {
+				setSelectionErrorIds(filteredErrors.map((r) => r.seatId));
+
+				filteredErrors
+					.map((r) => r.message as string)
+					.forEach((error) => toast.error(error));
+			}
+			setSelectionSuccessIds(filteredSuccess.map((r) => r.seatId));
+		}
+	}, [seats, selectedSeat]);
+
+	return {
+		seatsByRow,
+		seatsByColumn,
+		selectedSeat,
+		onSelectSeat,
+		selectionErrorIds,
+		setSelectionErrorIds,
+		selectionSuccessIds,
+		setSelectionSuccessIds,
+	};
 }


### PR DESCRIPTION
Refactor seat selection state management in the Seats component. Remove
local state for selection error and success ids and utilize the state
management provided by the useSeatSelection hook. Update references to
these states accordingly in the Seats component to maintain consistency
and improve code organization.