### PR TITLE
feat: Clear selection success and error IDs on seat selection

### DIFF
--- a/src/hooks/use-seat-selection.ts
+++ b/src/hooks/use-seat-selection.ts
@@ -38,6 +38,8 @@ export function useSeatSelection(seats: Seat[]): {
 
 	const onSelectSeat = useCallback(
 		(seatId: string) => {
+			setSelectionSuccessIds([]);
+			setSelectionErrorIds([]);
 			toast.dismiss();
 			const seat = seats.find((_seat) => _seat.id === seatId);
 			if (!seat) return;


### PR DESCRIPTION
Clear the selectionSuccessIds and selectionErrorIds arrays and dismiss any previous toasts when selecting a seat.