### PR TITLE
feat: Add currency formatting to seat prices

### DIFF
--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useSeatSelection } from "@/hooks/use-seat-selection";
+import { formatCurrency } from "@/lib/formatter";
 import { type PickSeatRes, type Seat } from "@/lib/seat";
 import { cn } from "@/lib/utils";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
-import { formatCurrency } from "@/lib/formatter";
 
 interface SeatsProps {
 	seats: Seat[];

--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -7,6 +7,7 @@ import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { ScrollArea, ScrollBar } from "./ui/scroll-area";
+import { formatCurrency } from "@/lib/formatter";
 
 interface SeatsProps {
 	seats: Seat[];
@@ -104,7 +105,11 @@ function Seats({ seats }: SeatsProps): JSX.Element {
 					}
 					onClick={submitSelectSeat}
 				>
-					{isSubmitting ? "..." : "Submit"}
+					{isSubmitting
+						? "..."
+						: `Buy Now - ${formatCurrency(
+								seatSelection.totalAmountForSeats,
+							)}`}
 				</Button>
 			</div>
 		</div>
@@ -185,11 +190,7 @@ function SeatsSeat(props: {
 		>
 			<span className="font-bold">{props.seat.id}</span>
 			<span className="text-[8px] text-muted-foreground">
-				{new Intl.NumberFormat("en-US", {
-					style: "currency",
-					currency: "MYR",
-					maximumFractionDigits: 0,
-				}).format(props.seat.price)}
+				{formatCurrency(props.seat.price)}
 			</span>
 		</Button>
 	);

--- a/src/hooks/use-seat-selection.ts
+++ b/src/hooks/use-seat-selection.ts
@@ -23,8 +23,11 @@ export function useSeatSelection(seats: Seat[]): {
 	setSelectionErrorIds: Dispatch<SetStateAction<string[]>>;
 	selectionSuccessIds: string[];
 	setSelectionSuccessIds: Dispatch<SetStateAction<string[]>>;
+	totalAmountForSeats: number;
 } {
 	const [selectedSeat, setSelectedSeat] = useState<Seat[]>([]);
+
+	const [totalAmountForSeats, setTotalAmountForSeats] = useState(0);
 
 	const [selectionErrorIds, setSelectionErrorIds] = useState<string[]>([]);
 
@@ -77,6 +80,16 @@ export function useSeatSelection(seats: Seat[]): {
 		}
 	}, [seats, selectedSeat]);
 
+	useEffect(() => {
+		setTotalAmountForSeats(0);
+		if (selectedSeat.length > 0) {
+			const totalAmount = selectedSeat.reduce((acc, seat) => {
+				return acc + seat.price;
+			}, 0);
+			setTotalAmountForSeats(totalAmount);
+		}
+	}, [selectedSeat]);
+
 	return {
 		seatsByRow,
 		seatsByColumn,
@@ -86,5 +99,6 @@ export function useSeatSelection(seats: Seat[]): {
 		setSelectionErrorIds,
 		selectionSuccessIds,
 		setSelectionSuccessIds,
+		totalAmountForSeats,
 	};
 }

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -1,0 +1,7 @@
+export function formatCurrency(amount: number): string {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "MYR",
+		maximumFractionDigits: 0,
+	}).format(amount);
+}


### PR DESCRIPTION
Added a new function `formatCurrency` in `formatter.ts` to format seat prices
with the currency symbol. Refactored `Seats` component to display total amount
for selected seats with the currency format. Updated `useSeatSelection` hook
to calculate and display total amount for selected seats.