### PR TITLE
feat: Update seat display to show label instead of id

### DIFF
--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -189,7 +189,7 @@ function SeatsSeat(props: {
 					: "",
 			)}
 		>
-			<span className="font-bold">{props.seat.id}</span>
+			<span className="font-bold">{props.seat.label}</span>
 			<span className="text-[8px] text-muted-foreground">
 				{formatCurrency(props.seat.price)}
 			</span>


### PR DESCRIPTION
Changed the seat display to show the seat label instead of the id for better
clarity and user experience.