### PR TITLE
feat: Add useRouter hook to TicketCard to enable navigation to seat selection

### DIFF
--- a/src/components/seats.tsx
+++ b/src/components/seats.tsx
@@ -75,7 +75,7 @@ function Seats({ seatSelection }: SeatsProps): JSX.Element {
 	}, [seatSelection]);
 
 	return (
-		<div className="flex flex-col gap-4">
+		<div id="seat-selection" className="flex flex-col gap-4">
 			<ScrollArea className="border whitespace-nowrap rounded-md p-4">
 				<div className="flex flex-col items-center gap-4">
 					<div className="bg-muted rounded w-52 h-10 grid items-center text-center">

--- a/src/components/ticket-card.tsx
+++ b/src/components/ticket-card.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { CheckIcon } from "lucide-react";
 import { type Dispatch, type SetStateAction } from "react";
 import { Separator } from "./ui/separator";
+import { useRouter } from "next/navigation";
 
 interface TicketCardProps {
 	seats: Seat[];
@@ -16,6 +17,8 @@ interface TicketCardProps {
 }
 
 export default function TicketCard(props: TicketCardProps): JSX.Element {
+	const router = useRouter();
+
 	const isSelected = props.selectedTicket === props.ticket.id;
 
 	const selectedErrorDetails = props.seats.filter((seat) => {
@@ -41,6 +44,7 @@ export default function TicketCard(props: TicketCardProps): JSX.Element {
 			props.setSelectedTicket(null);
 		} else {
 			props.setSelectedTicket(props.ticket.id);
+			router.push("#seat-selection");
 		}
 	}
 

--- a/src/components/ticket-card.tsx
+++ b/src/components/ticket-card.tsx
@@ -3,9 +3,9 @@ import { type Seat } from "@/lib/seat";
 import { type Ticket } from "@/lib/ticket";
 import { cn } from "@/lib/utils";
 import { CheckIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { type Dispatch, type SetStateAction } from "react";
 import { Separator } from "./ui/separator";
-import { useRouter } from "next/navigation";
 
 interface TicketCardProps {
 	seats: Seat[];


### PR DESCRIPTION
Add the useRouter hook from next/navigation to TicketCard component to enable redirection to the seat selection section when a ticket is selected.